### PR TITLE
docs[common]: fix spacing between team member names

### DIFF
--- a/docs/Common.tex
+++ b/docs/Common.tex
@@ -1,12 +1,12 @@
 %% Common Parts
 
 \newcommand{\progname}{Software Engineering} % PUT YOUR PROGRAM NAME HERE
-\newcommand{\authname}{Team 8, Rhythm Rangers
-Ansel Chen
-Muhammad Jawad
-Mohamad-Hassan Bahsoun
-Matthew Baleanu
-Ahmed Al-Hayali} % AUTHOR NAMES                  
+\newcommand{\authname}{Team 8 -- Rhythm Rangers\\
+\\ Ansel Chen
+\\ Muhammad Jawad
+\\ Mohamad-Hassan Bahsoun
+\\ Matthew Baleanu
+\\ Ahmed Al-Hayali} % AUTHOR NAMES                  
 
 \usepackage{hyperref}
     \hypersetup{colorlinks=true, linkcolor=blue, citecolor=blue, filecolor=blue,


### PR DESCRIPTION
## Description
<!--Describe the purpose of this pull request.-->
- Quick-fix small formatting issues in `Common.tex`.

## Changes
<!--List the changes you have made.-->
- Add em-dash between team number & name.
- Separate team member names onto different lines.

## Additional Information
<!--Include any additional information, such as how to test your changes.-->
N/A

## Checklist
- [x] Documentation updated