### PR TITLE
docs[MG-4.1] - added anticipated changes to the doc

### DIFF
--- a/docs/Design/SoftArchitecture/MG.tex
+++ b/docs/Design/SoftArchitecture/MG.tex
@@ -158,16 +158,18 @@ adapted here is called design for
 change.
 
 \begin{description}
-\item[\refstepcounter{acnum} \actheacnum \label{acHardware}:] The specific
-  hardware on which the software is running.
-\item[\refstepcounter{acnum} \actheacnum \label{acInput}:] The format of the
-  initial input data.
-\item ...
+\item[\refstepcounter{acnum} \actheacnum \label{acHardware}:] Format and constraints of the initial input data
+\item[\refstepcounter{acnum} \actheacnum \label{acInput}:] The APIs used to fetch data
+\item[\refstepcounter{acnum} \actheacnum \label{acInput}:] Feature extraction algorithms
+\item[\refstepcounter{acnum} \actheacnum \label{acInput}:] Song Recommendation algorithm
+\item[\refstepcounter{acnum} \actheacnum \label{acInput}:] Database Strucutre and Content
+\item[\refstepcounter{acnum} \actheacnum \label{acInput}:] GUI Implementation
+\item[\refstepcounter{acnum} \actheacnum \label{acInput}:] Addition of new features
 \end{description}
 
-\wss{Anticipated changes relate to changes that would be made in requirements,
-design or implementation choices.  They are not related to changes that are made
-at run-time, like the values of parameters.}
+% \wss{Anticipated changes relate to changes that would be made in requirements,
+% design or implementation choices.  They are not related to changes that are made
+% at run-time, like the values of parameters.}
 
 \subsection{Unlikely Changes} \label{SecUchange}
 


### PR DESCRIPTION
This part of the MG doc deals with the anticipated changes. 

I believe that we may need to add more depending on the different modules not sure though

What to do
- [x] checked the anticipated changes 
- [ ] made suggestions 